### PR TITLE
Add Gemini API serverless function

### DIFF
--- a/api/gemini.js
+++ b/api/gemini.js
@@ -1,0 +1,15 @@
+export default async function handler(req, res) {
+  const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+  const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${GEMINI_API_KEY}`
+    },
+    body: JSON.stringify(req.body)
+  });
+
+  const data = await response.json();
+  res.status(200).json(data);
+}


### PR DESCRIPTION
## Summary
- implement a Gemini serverless function under `api/gemini.js`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_683f8bd684c083248d6fa4772fb6bbd3