### PR TITLE
Fix error when anime lookup fails

### DIFF
--- a/keywordSearch.html
+++ b/keywordSearch.html
@@ -202,10 +202,15 @@ async function getAnimeId(animeName) {
 
     try {
         const data = await graphQL(query, variables);
-        id = data.data.Media.id;
-        bannerImage = data.data.Media.bannerImage;
-        description = data.data.Media.description;
-        return data.data.Media.id;
+        if (data && data.data && data.data.Media) {
+            id = data.data.Media.id;
+            bannerImage = data.data.Media.bannerImage;
+            description = data.data.Media.description;
+            return data.data.Media.id;
+        } else {
+            console.error('Anime not found:', animeName);
+            return null;
+        }
     } catch (error) {
         handleError(error);
     }
@@ -277,6 +282,10 @@ async function handleData() {
     console.log(`Current keywords: ${keywords.join(', ')}`)
     const anime = await openAIResponse(keywords.join(", "));
     var animeID = await getAnimeId(anime);
+    if (!animeID) {
+        document.getElementById('content').innerHTML = `<p>No results found for "${anime}".</p>`;
+        return;
+    }
     var animeName = document.createElement('div');
     animeName.className = 'banner';
     animeName.textContent =  anime;


### PR DESCRIPTION
## Summary
- avoid TypeError if AniList doesn't return a Media object in **keywordSearch.html**
- show a message when the search fails instead of crashing

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f986d386c8324acae3748486ce6f5