### PR TITLE
Fix CORS for geminiKey API

### DIFF
--- a/api/geminiKey.js
+++ b/api/geminiKey.js
@@ -1,7 +1,13 @@
 export default function handler(req, res) {
+  // Allow requests from the production GitHub Pages domain
+  res.setHeader("Access-Control-Allow-Origin", "https://buba2.co");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
   const key = process.env.GEMINI_API_KEY;
   if (!key) {
     return res.status(500).json({ error: 'API key not configured' });
   }
+
   res.status(200).json({ key });
 }


### PR DESCRIPTION
## Summary
- enable CORS headers for `api/geminiKey.js`

## Testing
- `node --check api/geminiKey.js`

------
https://chatgpt.com/codex/tasks/task_e_683fa42a7bbc83248d1cd3532e78e292