### PR TITLE
Fix CORS for geminiKey API

### DIFF
--- a/api/geminiKey.js
+++ b/api/geminiKey.js
@@ -1,7 +1,19 @@
 export default function handler(req, res) {
+  const allowedOrigins = [
+    'https://buba2.co',
+    'https://barely-unofficial-barts-ani-list-2.vercel.app'
+  ];
+  const origin = req.headers.origin;
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   const key = process.env.GEMINI_API_KEY;
   if (!key) {
     return res.status(500).json({ error: 'API key not configured' });
   }
+
   res.status(200).json({ key });
 }

--- a/authorize.html
+++ b/authorize.html
@@ -53,8 +53,11 @@
 <script>
 async function getGeminiKey() {
     if (window.geminiKey) return window.geminiKey;
+    const apiHost = (location.hostname === 'buba2.co' || location.hostname === 'www.buba2.co')
+        ? 'https://barely-unofficial-barts-ani-list-2.vercel.app'
+        : '';
     try {
-        const res = await fetch('/api/geminiKey');
+        const res = await fetch(`${apiHost}/api/geminiKey`);
         const data = await res.json();
         window.geminiKey = data.key;
         return window.geminiKey;

--- a/keywordSearch.html
+++ b/keywordSearch.html
@@ -236,8 +236,11 @@ async function graphQL(query, variables) {
 
 async function getGeminiKey() {
     if (window.geminiKey) return window.geminiKey;
+    const apiHost = (location.hostname === 'buba2.co' || location.hostname === 'www.buba2.co')
+        ? 'https://barely-unofficial-barts-ani-list-2.vercel.app'
+        : '';
     try {
-        const res = await fetch('/api/geminiKey');
+        const res = await fetch(`${apiHost}/api/geminiKey`);
         const data = await res.json();
         window.geminiKey = data.key;
         return window.geminiKey;

--- a/result.html
+++ b/result.html
@@ -87,8 +87,11 @@
 <script>
 async function getGeminiKey() {
     if (window.geminiKey) return window.geminiKey;
+    const apiHost = (location.hostname === 'buba2.co' || location.hostname === 'www.buba2.co')
+        ? 'https://barely-unofficial-barts-ani-list-2.vercel.app'
+        : '';
     try {
-        const res = await fetch('/api/geminiKey');
+        const res = await fetch(`${apiHost}/api/geminiKey`);
         const data = await res.json();
         window.geminiKey = data.key;
         return window.geminiKey;

--- a/review.html
+++ b/review.html
@@ -81,8 +81,11 @@
 
 async function getGeminiKey() {
     if (window.geminiKey) return window.geminiKey;
+    const apiHost = (location.hostname === 'buba2.co' || location.hostname === 'www.buba2.co')
+        ? 'https://barely-unofficial-barts-ani-list-2.vercel.app'
+        : '';
     try {
-        const res = await fetch('/api/geminiKey');
+        const res = await fetch(`${apiHost}/api/geminiKey`);
         const data = await res.json();
         window.geminiKey = data.key;
         return window.geminiKey;


### PR DESCRIPTION
## Summary
- enable CORS headers for `api/geminiKey.js`
- allow requests from Vercel deployment URL

## Testing
- `node --check api/geminiKey.js`


------
https://chatgpt.com/codex/tasks/task_e_683fa42a7bbc83248d1cd3532e78e292